### PR TITLE
Dependency version and keywords

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description"       : "ZF2 PHP Wrapper for Vu/AMQPCarapace",
     "license"           : "BSD-3-Clause",
     "minimum-stability" : "dev",
+    "keywords"          : ["rabbitmq","message","queue","zf2","amqp"],
     "authors" : [
         {
             "name" : "Michael Crawford",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "vu/amqp-carapace"                  : "0.1.0",
         "zendframework/zend-servicemanager" : ">=2.2",
         "zendframework/zend-stdlib"         : ">=2.2",
-        "vu/zf2-test-extensions"            : "1.0"
+        "vu/zf2-test-extensions"            : "1.0.*"
     },
     "require-dev"       : {
         "phpunit/phpunit"      : "3.7.*",


### PR DESCRIPTION
## Dependency Version

Updated the zf2-test-extensions dependency to be 1.0.\* so that new minor versions may be used. This is to correct the zf2 dependency error between zf2-test-extensions version 1.0 and 1.0.1.
## Keywords

Also added keywords so that this package may be searched and filtered.
